### PR TITLE
bluetooth: set firmware patch file name

### DIFF
--- a/rootdir/system/etc/bluetooth/bt_vendor.conf
+++ b/rootdir/system/etc/bluetooth/bt_vendor.conf
@@ -3,3 +3,4 @@ UartPort = /dev/ttyHS0
 
 # Firmware patch file location
 FwPatchFilePath = /system/etc/firmware/
+FwPatchFileName = BCM43xx.hcd


### PR DESCRIPTION
libbt-vendor wants BCM4335C0.hcd currently, but we have BCM43xx.hcd, so set the name to that.
