### PR TITLE
init: Fix a typo

### DIFF
--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -50,11 +50,11 @@ on init
     mkdir /dev/bus 0755 root root
     mkdir /dev/bus/usb 0755 root root
 
-    #Bluetooth address setting
+    # Bluetooth address setting
     setprop ro.bt.bdaddr_path "/data/etc/bluetooth_bdaddr"
-    chown bluetooth bluetooth ro.bt.bdaddr_path
+    chown bluetooth bluetooth ${ro.bt.bdaddr_path}
 
-    #Enable Bluetooth WakeUp trigger
+    # Enable Bluetooth WakeUp trigger
     chown bluetooth net_bt_admin /proc/bluetooth/wakeup/proto
     chmod 0660 /proc/bluetooth/wakeup/proto
 


### PR DESCRIPTION
We want to chown $property, not property itself.
