### PR TITLE
Revert "mkqcdtimage: use dts from out folder"

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -35,7 +35,7 @@ BOARD_RAMDISK_OFFSET     := 0x02000000
 BOARD_KERNEL_BOOTIMG := true
 BOARD_CUSTOM_MKBOOTIMG := mkqcdtbootimg
 BOARD_MKBOOTIMG_ARGS := --ramdisk_offset $(BOARD_RAMDISK_OFFSET) --tags_offset $(BOARD_KERNEL_TAGS_OFFSET)
-BOARD_MKBOOTIMG_ARGS += --dt_dir out/target/product/$(TARGET_DEVICE)/dtbs
+BOARD_MKBOOTIMG_ARGS += --dt_dir device/sony/$(TARGET_DEVICE)/dtbs
 
 BOARD_KERNEL_CMDLINE := console=ttyHSL0,115200,n8 androidboot.hardware=shinano user_debug=31 msm_rtb.filter=0x37 ehci-hcd.park=3 selinux=0
 BOARD_KERNEL_CMDLINE += dwc3.maximum_speed=high dwc3_msm.prop_chg_detect=Y


### PR DESCRIPTION
This is just wrong, and hardcoded paths are always bad.
If anything, this should use $(OUT_DIR), or the proper kernel paths as needed.