### PR TITLE
Add timekeep fix for time persistence

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -157,6 +157,8 @@ PRODUCT_PACKAGES += \
     ta_qmi_service
 
 PRODUCT_PACKAGES += \
+    timekeep \
+    TimeKeep \
     thermanager \
     addrsetup
 

--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -77,9 +77,6 @@ on post-fs-data
     #Create directory for hostapd
     mkdir /data/hostapd 0770 system wifi
 
-    # Create /data/time folder for time-services
-    mkdir /data/time/ 0700 system system
-
     # Create directory used by audio subsystem
     mkdir /data/misc/audio 0770 audio audio
 
@@ -454,7 +451,7 @@ service charger /sbin/healthd -c
     critical
     seclabel u:r:healthd:s0
 
-service time_daemon /system/bin/time_daemon
+service timekeep /system/bin/timekeep restore
    class late_start
    user root
    group root


### PR DESCRIPTION
   **device.mk**:
Add timekeep to product packages
(Tested and working, but does it need both timekeep and TimeKeep? )
   **rootdir/init.shinano.rc**:
Add timekeep service and remove old directory
( Tested and working )

[ https://github.com/galaxyfreak/device-sony-yukon/commit/8156b05f858eb5e1e8867c7caf5247e366dca928#commitcomment-10121183 ]
Commit by galaxyfreak 
Comment on product packages by jerpelea