### PR TITLE
Revert "shinano: fix cmdline permission"

### DIFF
--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -17,7 +17,6 @@ import init.shinano.pwr.rc
 
 on early-init
     mount debugfs debugfs /sys/kernel/debug
-    chmod 644 /proc/cmdline
 
 on init
     mkdir /tmp


### PR DESCRIPTION
Reverts sonyxperiadev/device-sony-shinano#43

It *should* not be world readable, as it contains the IMEI and serial number.