### PR TITLE
shinano: Fix typo

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -16,7 +16,7 @@ PRODUCT_VENDOR_KERNEL_HEADERS := device/sony/shinano/kernel-headers
 
 TARGET_ARCH := arm
 TARGET_ARCH_VARIANT := armv7-a-neon
-TARGET_BOARD_PLATFORM = msm8974
+TARGET_BOARD_PLATFORM := msm8974
 TARGET_CPU_ABI := armeabi-v7a
 TARGET_CPU_ABI2 := armeabi
 TARGET_CPU_VARIANT := krait


### PR DESCRIPTION
See AOSP devices is TARGET_BOARD_PLATFORM := instead TARGET_BOARD_PLATFORM =

https://android.googlesource.com/device/asus/fugu/+/android-5.1.0_r1/BoardConfig.mk string 30

https://android.googlesource.com/device/asus/flo/+/android-5.1.0_r1/BoardConfigCommon.mk string 46