### PR TITLE
shinano: Set HWUI memory limits props

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -27,6 +27,18 @@ mmp.enable.3g2=true
 mm.enable.smoothstreaming=true
 media.aac_51_output_enabled=true
 
+ro.hwui.texture_cache_size=48
+ro.hwui.layer_cache_size=32
+ro.hwui.r_buffer_cache_size=4
+ro.hwui.path_cache_size=24
+ro.hwui.gradient_cache_size=1
+ro.hwui.drop_shadow_cache_size=5
+ro.hwui.texture_cache_flushrate=0.5
+ro.hwui.text_small_cache_width=1024
+ro.hwui.text_small_cache_height=1024
+ro.hwui.text_large_cache_width=2048
+ro.hwui.text_large_cache_height=1024
+
 #37491 is decimal sum of supported codecs in AAL
 #codecs: AVI AC3 ASF AAC QCP DTS 3G2 MP2TS
 mm.enable.qcom_parser=37491


### PR DESCRIPTION
These values are not defined by AOSP as dalvik-heap but these are needed by all shinano devices for set HWUI memory limits

These values can be founded in bruild.prop (Sony Stock) by all shinano devices

Signed-off-by: David Viteri <davidteri91@gmail.com>