### PR TITLE
shinano: enable miracast bool support

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -195,6 +195,8 @@
         <item>60</item>
     </integer-array>
 
+    <bool name="config_enableWifiDisplay">true</bool>
+
     <!-- Wifi driver supports batched scan -->
     <bool translatable="false" name="config_wifi_batched_scan_supported">true</bool>
 

--- a/rootdir/system/etc/audio_policy.conf
+++ b/rootdir/system/etc/audio_policy.conf
@@ -131,7 +131,7 @@ audio_hw_modules {
   r_submix {
     outputs {
       submix {
-        sampling_rates 48000
+        sampling_rates 44100|48000
         channel_masks AUDIO_CHANNEL_OUT_STEREO
         formats AUDIO_FORMAT_PCM_16_BIT
         devices AUDIO_DEVICE_OUT_REMOTE_SUBMIX
@@ -139,7 +139,7 @@ audio_hw_modules {
     }
     inputs {
       submix {
-        sampling_rates 48000
+        sampling_rates 44100|48000
         channel_masks AUDIO_CHANNEL_IN_STEREO
         formats AUDIO_FORMAT_PCM_16_BIT
         devices AUDIO_DEVICE_IN_REMOTE_SUBMIX


### PR DESCRIPTION
also update sampling rates from 48000 to 44100|48000

Product Package is compiled for a while: https://github.com/sonyxperiadev/device-sony-shinano/blob/master/device.mk#L79

Signed-off-by: David Viteri <davidteri91@gmail.com>