### PR TITLE
 fstab: Update syntax for external sdcard 

### DIFF
--- a/rootdir/fstab.shinano
+++ b/rootdir/fstab.shinano
@@ -4,5 +4,5 @@
 /dev/block/platform/msm_sdcc.1/by-name/boot         /boot        emmc    defaults                                         defaults
 /dev/block/platform/msm_sdcc.1/by-name/FOTAKernel   /recovery    emmc    defaults                                         defaults
 
-/devices/msm_sdcc.2/mmc_host                        auto         auto    nosuid,nodev                                     voldmanaged=sdcard1:auto
+/devices/msm_sdcc.2/mmc_host*                        auto         auto    nosuid,nodev                                     voldmanaged=sdcard1:auto
 /devices/platform/xhci-hcd                          auto         auto    nosuid,nodev                                     voldmanaged=usbdisk:auto


### PR DESCRIPTION
logcat:
```
W/DirectVolume(  272): Deprecated implied prefix pattern detected, please use '/devices/msm_sdcc.2/mmc_host*' instead
```