### PR TITLE
shinano: init: Assign bluetooth DUN port-bridge to bt stack group

### DIFF
--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -161,14 +161,15 @@ on boot
 
     # bluetooth DUN port-bridge
     chmod 0660 /dev/smd7
-    chown bluetooth bluetooth /dev/smd7
+    chown bluetooth net_bt_stack /dev/smd7
 
     # bluetooth modules
-    chown system system /sys/module/sco/parameters/disable_esco
-    chown bluetooth net_bt_stack /sys/module/bluetooth_power/parameters/power
-    chown bluetooth net_bt_stack /sys/module/hci_smd/parameters/hcismd_set
-    chmod 0660 /sys/module/bluetooth_power/parameters/power
-    chmod 0660 /sys/module/hci_smd/parameters/hcismd_set
+    chown system system /sys/module/bluetooth/parameters/disable_ertm
+    chown system system /sys/module/bluetooth/parameters/disable_esco
+    chown system system /sys/module/bluetooth/parameters/enable_hs
+    chmod 0644 /sys/module/bluetooth/parameters/disable_ertm
+    chmod 0644 /sys/module/bluetooth/parameters/disable_esco
+    chmod 0644 /sys/module/bluetooth/parameters/enable_hs
 
     # bluetooth rfkill
     chown bluetooth net_bt_stack /sys/class/rfkill/rfkill0/type
@@ -182,10 +183,6 @@ on boot
     chmod 0660 /proc/bluetooth/sleep/proto
     chmod 0660 /proc/bluetooth/sleep/lpm
     chmod 0660 /proc/bluetooth/sleep/btwrite
-
-    # bluetooth UART dev
-    chown bluetooth net_bt_stack /sys/devices/f995d000.uart/clock
-    chmod 0660 /sys/devices/f995d000.uart/clock
 
     #Create QMUX deamon socket area
     mkdir /dev/socket/qmux_radio 0770 radio radio

--- a/rootdir/ueventd.shinano.rc
+++ b/rootdir/ueventd.shinano.rc
@@ -9,10 +9,10 @@
 /dev/smd_cxm_qmi          0640   radio      radio
 /dev/smd5                 0660   system     system
 /dev/smd6                 0660   system     system
-/dev/smd7                 0660   bluetooth  bluetooth
+/dev/smd7                 0660   bluetooth  net_bt_stack
 /dev/smd11                0660   radio      radio
 /dev/radio0               0640   system     system
-/dev/rfcomm0              0660   bluetooth  bluetooth
+/dev/rfcomm0              0660   bluetooth  net_bt_stack
 /dev/smdcntl0             0640   radio      radio
 /dev/smdcntl1             0640   radio      radio
 /dev/smdcntl2             0640   radio      radio
@@ -81,10 +81,9 @@
 /sys/devices/virtual/smdpkt/smdcntl* open_timeout 0664 radio  radio
 
 # BT
-/dev/hidraw*                                0666 system    system
-/dev/rfkill                                 0660 bluetooth net_bt_stack
-/dev/ttyHS0                                 0660 bluetooth net_bt_stack
-/sys/devices/f995d000.uart/clock            0660 bluetooth net_bt_stack
+/dev/hidraw*                                        0666 system    system
+/dev/rfkill                                         0660 bluetooth net_bt_stack
+/dev/ttyHS0                                         0660 bluetooth net_bt_stack
 
 # NFC
 /dev/nfc-nci                                        0660 nfc nfc


### PR DESCRIPTION
also, remove reprecated entries.

Signed-off-by: Humberto Borba <humberos@gmail.com>