### PR TITLE
shinano: init: add missed permissions

### DIFF
--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -148,6 +148,28 @@ on early-boot
     setrlimit 8 67108864 67108864
 
 on boot
+    # PM8941 flash
+    chown media system /sys/class/misc/pm8941-flash/device/current1
+    chown media system /sys/class/misc/pm8941-flash/device/current2
+    chown media system /sys/class/misc/pm8941-flash/device/fault_status
+    chown media system /sys/class/misc/pm8941-flash/device/fine_current1
+    chown media system /sys/class/misc/pm8941-flash/device/fine_current2
+    chown media system /sys/class/misc/pm8941-flash/device/flash_timer
+    chown media system /sys/class/misc/pm8941-flash/device/mask_clamp_current
+    chown media system /sys/class/misc/pm8941-flash/device/mask_enable
+    chown media system /sys/class/misc/pm8941-flash/device/max_current
+    chown media system /sys/class/misc/pm8941-flash/device/mode
+    chown media system /sys/class/misc/pm8941-flash/device/startup_delay
+    chown media system /sys/class/misc/pm8941-flash/device/strobe
+    chown media system /sys/class/misc/pm8941-flash/device/vph_pwr_droop
+
+    # Cover mode
+    chown system system /sys/devices/virtual/input/clearpad/cover_mode_enabled
+    chown system system /sys/devices/virtual/input/clearpad/cover_win_bottom
+    chown system system /sys/devices/virtual/input/clearpad/cover_win_left
+    chown system system /sys/devices/virtual/input/clearpad/cover_win_right
+    chown system system /sys/devices/virtual/input/clearpad/cover_win_top
+
     # bring CPUs online
     write /sys/module/msm_thermal/core_control/enabled 0
     write /sys/devices/system/cpu/cpu1/online 1
@@ -212,11 +234,15 @@ on boot
     symlink /dev/graphics/fb1 /dev/graphics/hdmi
 
     # Remove write permissions to video related nodes
+    chown system graphics /sys/class/graphics/fb1/avi_itc
+    chown system graphics /sys/class/graphics/fb1/avi_cn0_1
     chown system graphics /sys/class/graphics/fb1/hpd
     chown system graphics /sys/class/graphics/fb1/product_description
     chown system graphics /sys/class/graphics/fb1/vendor_name
     chown system graphics /sys/class/graphics/fb1/video_mode
     chown system graphics /sys/class/graphics/fb1/hdcp/tp
+    chmod 0664 /sys/class/graphics/fb1/avi_itc
+    chmod 0664 /sys/class/graphics/fb1/avi_cn0_1
     chmod 0664 /sys/class/graphics/fb1/hpd
     chmod 0664 /sys/class/graphics/fb1/product_description
     chmod 0664 /sys/class/graphics/fb1/vendor_name

--- a/rootdir/ueventd.shinano.rc
+++ b/rootdir/ueventd.shinano.rc
@@ -12,7 +12,8 @@
 /dev/smd7                 0660   bluetooth  net_bt_stack
 /dev/smd11                0660   radio      radio
 /dev/radio0               0640   system     system
-/dev/rfcomm0              0660   bluetooth  net_bt_stack
+/dev/ccid_bulk            0660   system     system
+/dev/ccid_ctrl            0660   system     system
 /dev/smdcntl0             0640   radio      radio
 /dev/smdcntl1             0640   radio      radio
 /dev/smdcntl2             0640   radio      radio
@@ -80,10 +81,22 @@
 /dev/video33              0660   system     camera
 /sys/devices/virtual/smdpkt/smdcntl* open_timeout 0664 radio  radio
 
+# UIO devices
+/dev/uio0                 0660   system     system
+/dev/uio1                 0660   system     system
+/dev/uio2                 0660   system     system
+/dev/uio3                 0660   system     system
+
 # BT
 /dev/hidraw*                                        0666 system    system
 /dev/rfkill                                         0660 bluetooth net_bt_stack
 /dev/ttyHS0                                         0660 bluetooth net_bt_stack
+
+# Sensors
+/sys/devices/virtual/switch/dock        state       0660 system system
+/sys/devices/virtual/switch/hdmi        state       0660 system system
+/sys/devices/virtual/switch/hdmi_audio  state       0660 system system
+/sys/devices/virtual/switch/wfd         state       0660 system system
 
 # NFC
 /dev/nfc-nci                                        0660 nfc nfc
@@ -118,6 +131,8 @@
 # Clearphase Headphone
 /dev/clearphase_hp        0660  system      audio
 
+/sys/devices/virtual/graphics/fb1/avi_itc             0664 system graphics
+/sys/devices/virtual/graphics/fb1/avi_cn0_1           0664 system graphics
 /sys/devices/virtual/graphics/fb1/hpd                 0664 system graphics
 /sys/devices/virtual/graphics/fb1/video_mode          0664 system graphics
 /sys/devices/virtual/graphics/fb1/vendor_name         0664 system graphics


### PR DESCRIPTION
add some permissions for files/devices that are still
present at 3.10-BF64 kernel

these entries are present on shinano leo at least

Signed-off-by: Humberto Borba <humberos@gmail.com>