### PR TITLE
[Shinano] BoardConfig: Specify not to build any bootloader

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -22,7 +22,9 @@ TARGET_CPU_ABI2 := armeabi
 TARGET_CPU_VARIANT := krait
 TARGET_GLOBAL_CFLAGS += -mfpu=neon -mfloat-abi=softfp
 TARGET_GLOBAL_CPPFLAGS += -mfpu=neon -mfloat-abi=softfp
+
 TARGET_NO_RADIOIMAGE := true
+TARGET_NO_BOOTLOADER := true
 TARGET_NO_RECOVERY := false
 TARGET_NO_KERNEL := false
 


### PR DESCRIPTION
This is needed in case sooner or later the default will change.