### PR TITLE
shinano: avoid NetworkManagementSocketTagger fails

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -6,6 +6,7 @@ ril.subscription.types=NV,RUIM
 ro.use_data_netmgrd=true
 persist.data.netmgrd.qos.enable=true
 ro.data.large_tcp_window_size=true
+net.qtaguid_enabled=false
 
 # Enable Power save functionality for modem
 persist.radio.add_power_save=1


### PR DESCRIPTION
saw on leo:

         W/NetworkManagementSocketTagger( 5828): untagSocket(85) failed with errno -22
         I/qtaguid ( 5828): Failed write_ctrl(u 55) res=-1 errno=22
         I/qtaguid ( 5828): Untagging socket 55 failed errno=-22
         W/NetworkManagementSocketTagger( 5828): untagSocket(55) failed with errno -22
         I/qtaguid ( 5828): Failed write_ctrl(u 76) res=-1 errno=22
         I/qtaguid ( 5828): Untagging socket 76 failed errno=-22
         W/NetworkManagementSocketTagger( 5828): untagSocket(76) failed with errno -22
         I/qtaguid ( 5828): Failed write_ctrl(u 69) res=-1 errno=22
         I/qtaguid ( 5828): Untagging socket 69 failed errno=-22
         W/NetworkManagementSocketTagger( 5828): untagSocket(69) failed with errno -22
         I/qtaguid ( 5828): Failed write_ctrl(u 39) res=-1 errno=22
         I/qtaguid ( 5828): Untagging socket 39 failed errno=-22

Signed-off-by: David Viteri <davidteri91@gmail.com>