### PR TITLE
shinano: fix inputs for usb and submix

### DIFF
--- a/rootdir/system/etc/audio_policy.conf
+++ b/rootdir/system/etc/audio_policy.conf
@@ -115,8 +115,8 @@ audio_hw_modules {
     inputs {
       usb_device {
         sampling_rates dynamic
-        channel_masks AUDIO_CHANNEL_IN_STEREO
-        formats AUDIO_FORMAT_PCM_16_BIT
+        channel_masks dynamic
+        formats dynamic
         devices AUDIO_DEVICE_IN_USB_DEVICE
       }
     }
@@ -133,8 +133,8 @@ audio_hw_modules {
     inputs {
       submix {
         sampling_rates 48000
-        channel_masks dynamic
-        formats dynamic
+        channel_masks AUDIO_CHANNEL_IN_STEREO
+        formats AUDIO_FORMAT_PCM_16_BIT
         devices AUDIO_DEVICE_IN_REMOTE_SUBMIX
       }
     }


### PR DESCRIPTION
Following hammerhead and (rhine - yukon)

Signed-off-by: David Viteri <davidteri91@gmail.com>