### PR TITLE
Art

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -98,7 +98,9 @@ BOARD_NFC_HAL_SUFFIX := $(TARGET_BOARD_PLATFORM)
 EXTENDED_FONT_FOOTPRINT := true
 
 # Enable dex-preoptimization to speed up first boot sequence
-WITH_DEXPREOPT := true
+ifeq ($(HOST_OS),linux)
+    WITH_DEXPREOPT ?= true
+endif
 
 BUILD_KERNEL := true
 -include vendor/sony/kernel/KernelConfig.mk

--- a/device.mk
+++ b/device.mk
@@ -200,6 +200,21 @@ PRODUCT_COPY_FILES += device/sample/etc/apns-full-conf.xml:system/etc/apns-conf.
 PRODUCT_PROPERTY_OVERRIDES += \
     keyguard.no_require_sim=true
 
+# ART
+PRODUCT_PROPERTY_OVERRIDES += \
+    dalvik.vm.dex2oat-Xms=64m \
+    dalvik.vm.dex2oat-Xmx=512m \
+    dalvik.vm.image-dex2oat-Xms=64m \
+    dalvik.vm.image-dex2oat-Xmx=64m \
+    dalvik.vm.dex2oat-filter=speed \
+    dalvik.vm.image-dex2oat-filter=speed
+
+# ART
+PRODUCT_DEX_PREOPT_DEFAULT_FLAGS := \
+    --compiler-filter=speed
+
+$(call add-product-dex-preopt-module-config,services,--compiler-filter=speed)
+
 # Platform specific default properties
 #
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
shinano: Check host for Dalvik preoptimization
Turn ON Dalvik preoptimization if the build is running on Linux hosts
(since host Dalvik isn't built for non-Linux hosts)

-------------------------------------------------------------------------------------------
shinano: Add ART dex2oat controls
These values are present at stock version.
Also, set compiler-filter as "speed" which compiles most methods and
maximizes runtime performance.