### PR TITLE
shinano: use proper black conceal color for our kernel 3.10

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -62,3 +62,5 @@ persist.sys.wfd.virtual=0
 
 wifi.interface=wlan0
 
+# conceal color
+persist.vidc.dec.conceal_color=32784


### PR DESCRIPTION
on this commit: https://github.com/sonyxperiadev/kernel/commit/20a6eb95259e965b9cfa72cb156ac3f384d2c39a // we can see as our actual kernel is using 0X8010 for black instead 0X8080 who is gray

aosp is using 0X8080 on actual android-5.1.1_r4 branch: https://android.googlesource.com/platform/hardware/qcom/media/+/android-5.1.1_r4/mm-video-v4l2/vidc/vdec/src/omx_vdec_msm8974.cpp (see string 129)

so change actual 0X8080 black with that one used by our kernel who is 0X8010 via prop persist.vidc.dec.conceal_color // commit 960a885dd7112b852c183ba5cad699ee24ae3a05 for platform/hardware/qcom/media

Signed-off-by: David Viteri <davidteri91@gmail.com>