### PR TITLE
castor_windy, scorpion_windy: fix missing libaudioamp and liblights

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,4 +1,4 @@
-ifeq ($(filter-out aries castor leo scorpion sirius,$(TARGET_DEVICE)),)
+ifeq ($(filter-out aries castor castor_windy leo scorpion scorpion_windy sirius,$(TARGET_DEVICE)),)
 
 LOCAL_PATH := $(call my-dir)
 

--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -107,3 +107,26 @@ endif
 
 BUILD_KERNEL := true
 -include vendor/sony/kernel/KernelConfig.mk
+
+# SELinux
+include device/qcom/sepolicy/sepolicy.mk
+
+BOARD_SEPOLICY_DIRS += \
+    device/sony/shinano/sepolicy
+
+BOARD_SEPOLICY_UNION += \
+    addrsetup.te \
+    device.te \
+    file.te \
+    property.te \
+    sct.te \
+    sensors.te \
+    service.te \
+    system_app.te \
+    tad.te \
+    ta_qmi.te \
+    thermanager.te \
+    timekeep.te \
+    file_contexts \
+    property_contexts \
+    service_contexts

--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -347,7 +347,7 @@ on boot
     write /sys/bus/msm_subsys/devices/subsys3/restart_level "related"
 
 #SONY misc
-service tad_static /system/bin/tad_static /dev/block/mmcblk0 1,16
+service tad_static /system/bin/tad_static /dev/block/platform/msm_sdcc.1/by-name/TA 0,16
     user root
     group root
     socket tad stream 0660 system system

--- a/sepolicy/addrsetup.te
+++ b/sepolicy/addrsetup.te
@@ -1,0 +1,17 @@
+type addrsetup, domain;
+type addrsetup_exec, exec_type, file_type;
+
+# Started by init
+init_daemon_domain(addrsetup)
+
+# Connect to /dev/socket/tad
+unix_socket_connect(addrsetup, tad, tad)
+
+allow addrsetup self:capability { dac_override };
+
+allow addrsetup system_data_file:dir w_dir_perms;
+type_transition addrsetup system_data_file:file addrsetup_data_file "bluetooth_bdaddr";
+allow addrsetup addrsetup_data_file:dir rw_dir_perms;
+allow addrsetup addrsetup_data_file:file create_file_perms;
+
+allow addrsetup sysfs_addrsetup:file rw_file_perms;

--- a/sepolicy/device.te
+++ b/sepolicy/device.te
@@ -1,0 +1,1 @@
+type trim_area_partition_device, dev_type;

--- a/sepolicy/file.te
+++ b/sepolicy/file.te
@@ -1,0 +1,6 @@
+type tad_socket, file_type;
+type ta_data_file, file_type;
+
+type addrsetup_data_file, file_type, data_file_type;
+
+type sysfs_addrsetup, fs_type, sysfs_type;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,0 +1,21 @@
+# Trim Area daemon
+/dev/socket/tad                        u:object_r:tad_socket:s0
+
+/dev/pn547                             u:object_r:nfc_device:s0
+
+# Block devices
+/dev/block/platform/msm_sdcc\.1/by-name/modemst1          u:object_r:modem_efs_partition_device:s0
+/dev/block/platform/msm_sdcc\.1/by-name/modemst2          u:object_r:modem_efs_partition_device:s0
+/dev/block/platform/msm_sdcc\.1/by-name/fsg               u:object_r:modem_efs_partition_device:s0
+/dev/block/platform/msm_sdcc\.1/by-name/TA                u:object_r:trim_area_partition_device:s0
+
+/data/etc/bluetooth_bdaddr             u:object_r:addrsetup_data_file:s0
+
+/system/bin/addrsetup                  u:object_r:addrsetup_exec:s0
+/system/bin/sct_service                u:object_r:sct_exec:s0
+/system/bin/tad_static                 u:object_r:tad_exec:s0
+/system/bin/ta_qmi_service             u:object_r:ta_qmi_exec:s0
+/system/bin/thermanager                u:object_r:thermanager_exec:s0
+/system/bin/timekeep                   u:object_r:timekeep_exec:s0
+
+/sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr    u:object_r:sysfs_addrsetup:s0

--- a/sepolicy/property.te
+++ b/sepolicy/property.te
@@ -1,0 +1,1 @@
+type timekeep_prop, property_type;

--- a/sepolicy/property_contexts
+++ b/sepolicy/property_contexts
@@ -1,0 +1,1 @@
+persist.sys.timeadjust         u:object_r:timekeep_prop:s0

--- a/sepolicy/sct.te
+++ b/sepolicy/sct.te
@@ -1,0 +1,11 @@
+type sct, domain;
+type sct_exec, exec_type, file_type;
+
+# Started by init
+init_daemon_domain(sct)
+
+allow sct self:socket create_socket_perms;
+allow sct self:capability { net_raw };
+
+# Access to /dev/smem_log
+allow sct smem_log_device:chr_file rw_file_perms;

--- a/sepolicy/sensors.te
+++ b/sepolicy/sensors.te
@@ -1,0 +1,4 @@
+# Connect to /dev/socket/tad
+unix_socket_connect(sensors, tad, tad)
+
+allow sensors self:capability { net_raw };

--- a/sepolicy/service.te
+++ b/sepolicy/service.te
@@ -1,0 +1,1 @@
+type timekeep_service,           service_manager_type;

--- a/sepolicy/service_contexts
+++ b/sepolicy/service_contexts
@@ -1,0 +1,1 @@
+com.sony.timekeep        u:object_r:timekeep_service:s0

--- a/sepolicy/system_app.te
+++ b/sepolicy/system_app.te
@@ -1,0 +1,1 @@
+allow system_app timekeep_prop:property_service set;

--- a/sepolicy/ta_qmi.te
+++ b/sepolicy/ta_qmi.te
@@ -1,0 +1,19 @@
+type ta_qmi, domain;
+type ta_qmi_exec, exec_type, file_type;
+
+# Started by init
+init_daemon_domain(ta_qmi)
+
+# XXX: What exactly is this needed for? - Need to investigate
+allow ta_qmi self:capability { dac_override net_raw };
+
+allow ta_qmi self:socket create_socket_perms;
+
+# Connect to /dev/socket/tad
+unix_socket_connect(ta_qmi, tad, tad)
+
+# Wakelocks!
+wakelock_use(ta_qmi)
+
+# Access to /dev/smem_log
+allow ta_qmi smem_log_device:chr_file rw_file_perms;

--- a/sepolicy/tad.te
+++ b/sepolicy/tad.te
@@ -1,0 +1,9 @@
+type tad, domain;
+type tad_exec, exec_type, file_type;
+
+# Started by init
+init_daemon_domain(tad)
+
+# Allow tad to work it's magic
+allow tad block_device:dir search;
+allow tad trim_area_partition_device:blk_file rw_file_perms;

--- a/sepolicy/thermanager.te
+++ b/sepolicy/thermanager.te
@@ -1,0 +1,11 @@
+type thermanager, domain;
+type thermanager_exec, exec_type, file_type;
+
+# Started by init
+init_daemon_domain(thermanager)
+
+allow thermanager self:capability dac_override;
+allow thermanager { sysfs sysfs_devices_system_cpu }:file write;
+allow thermanager { sysfs_thermal sysfs_usb_supply }:dir search;
+allow thermanager sysfs_thermal:{ lnk_file file } rw_file_perms;
+allow thermanager sysfs_usb_supply:file rw_file_perms;

--- a/sepolicy/timekeep.te
+++ b/sepolicy/timekeep.te
@@ -1,0 +1,7 @@
+type timekeep, domain;
+type timekeep_exec, exec_type, file_type;
+
+# Started by init
+init_daemon_domain(timekeep)
+
+allow timekeep self:capability { sys_time };


### PR DESCRIPTION
The condition filtered out castor_windy and thus libaudioamp and liblights were not included. This resulted in non-working brightness control.

I think scorpion_windy should also be added to the list, but I don't have a device to test, so I didn't push this change.