### PR TITLE
shinano: fstab: Add flag to external sd mount

### DIFF
--- a/rootdir/fstab.shinano
+++ b/rootdir/fstab.shinano
@@ -4,5 +4,5 @@
 /dev/block/platform/msm_sdcc.1/by-name/boot         /boot        emmc    defaults                                         defaults
 /dev/block/platform/msm_sdcc.1/by-name/FOTAKernel   /recovery    emmc    defaults                                         defaults
 
-/devices/msm_sdcc.2/mmc_host*                        auto         auto    nosuid,nodev                                     voldmanaged=sdcard1:auto
+/devices/msm_sdcc.2/mmc_host*                        auto         auto    nosuid,nodev                                     voldmanaged=sdcard1:auto,noemulatedsd
 /devices/platform/xhci-hcd                          auto         auto    nosuid,nodev                                     voldmanaged=usbdisk:auto


### PR DESCRIPTION
External sdcard is not an emulated sd.

line 69:
https://android.googlesource.com/platform/system/core/+/l-preview/fs_mgr/fs_mgr_fstab.c

Signed-off-by: Humberto Borba <humberos@gmail.com>