### PR TITLE
shinano: remove HEVC

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -127,7 +127,6 @@ PRODUCT_PACKAGES += \
     libOmxCore \
     libmm-omxcore \
     libOmxVdec \
-    libOmxVdecHevc \
     libOmxVenc
 
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
that seems to be provided by manufacturers due to it isn't compiled from aosp

Signed-off-by: David Viteri <davidteri91@gmail.com>