### PR TITLE
shinano: build copybit

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -108,6 +108,7 @@ PRODUCT_PACKAGES += \
 
 #GFX
 PRODUCT_PACKAGES += \
+    copybit.msm8974 \
     gralloc.msm8974 \
     hwcomposer.msm8974 \
     memtrack.msm8974 \


### PR DESCRIPTION
on start of the system I can see a log saying:

E/qdhwcomposer (283): FATAL ERROR: copybit hw module not found --> avoid it building from source

Signed-off-by: David Viteri <davidteri91@gmail.com>