### PR TITLE
shinano: Enable EMERGENCY mobile connections

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -150,6 +150,7 @@
         <item>"mobile_hipri,5,0,3,60000,true"</item>
         <item>"wifi_p2p,13,1,0,-1,true"</item>
         <item>"bluetooth,7,7,2,-1,true"</item>
+        <item>"mobile_emergency,15,0,2,-1,true</item>
     </string-array>
 
     <!-- Array of allowable ConnectivityManager network types for tethering -->


### PR DESCRIPTION
this commit add: https://android.googlesource.com/platform/frameworks/base/+/3e0e3bc%5E!/

having own networkAttributes will override one from aosp so add it

Signed-off-by: David Viteri <davidteri91@gmail.com>