### PR TITLE
Revert "shinano: use proper black conceal color for our kernel 3.10"

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -70,6 +70,3 @@ persist.sys.wfd.virtual=0
 
 # Wi-Fi interface name
 wifi.interface=wlan0
-
-# Conceal color
-persist.vidc.dec.conceal_color=32784


### PR DESCRIPTION
This reverts commit b27cb84ac13e3c547100c40ddc84ed9a8fd9540d.

see: https://android.googlesource.com/platform/hardware/qcom/media/+/android-6.0.0_r1/mm-video-v4l2/vidc/vdec/src/omx_vdec_msm8974.cpp#132

Conflicts:
	system.prop