### PR TITLE
shinano: ueventd: remove deprecated camera permissions

### DIFF
--- a/rootdir/ueventd.shinano.rc
+++ b/rootdir/ueventd.shinano.rc
@@ -145,5 +145,3 @@
 /sys/devices/virtual/graphics/fb1/product_description 0664 system graphics
 /sys/devices/virtual/graphics/fb1/hdcp/tp             0664 system graphics
 /sys/devices/virtual/graphics/fb2/ad                  0664 system graphics
-/sys/devices/sony_camera_0/info                       0666 camera camera
-/sys/devices/sony_camera_1/info                       0666 camera camera


### PR DESCRIPTION
following commit: c7c9d2bc451717c08ef151953c759a56d39025d0

Signed-off-by: David Viteri <davidteri91@gmail.com>