### PR TITLE
shinano: clanup init

### DIFF
--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -90,8 +90,7 @@ on post-fs-data
     mkdir /data/audio 0770 media audio
     chmod 2770 /data/audio
 
-    mkdir /data/data/media 0770 media media
-
+    # Create directory for Camera
     mkdir /data/misc/camera 0770 camera camera
 
     # Sensors


### PR DESCRIPTION
remove defined media directory by AOSP: https://android.googlesource.com/platform/system/core/+/android-6.0.0_r1/rootdir/init.rc#261

also update camera directory description

Signed-off-by: David Viteri <davidteri91@gmail.com>