### PR TITLE
shinano: move nfc lib to TARGET_DEVICE

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -138,8 +138,7 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     com.android.nfc_extras \
     NfcNci \
-    Tag \
-    nfc_nci.msm8974
+    Tag
 
 # GPS
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
https://android.googlesource.com/platform/external/libnfc-nci/+/android-6.0.0_r1/halimpl/pn54x/Android.mk#28

Signed-off-by: David Viteri <davidteri91@gmail.com>