### PR TITLE
shinano: fix header include

### DIFF
--- a/libaudioamp/tfa9890.c
+++ b/libaudioamp/tfa9890.c
@@ -21,6 +21,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 


### PR DESCRIPTION
avoid warning as:

device/sony/shinano/libaudioamp/tfa9890.c: In function 'tfa9890_prepare_for_ioctl':
device/sony/shinano/libaudioamp/tfa9890.c:53:2: warning: implicit declaration of function 'free' [-Wimplicit-function-declaration]
  free(tfa9890_param_data.data);
  ^
device/sony/shinano/libaudioamp/tfa9890.c:53:2: warning: incompatible implicit declaration of built-in function 'free'

Signed-off-by: David Viteri <davidteri91@gmail.com>