### PR TITLE
shinano: define multiwindows prop only on user builds

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -228,5 +228,7 @@ PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
     persist.data.qmi.adb_logmask=0
 
 # Enable MultiWindow
+ifeq ($(TARGET_BUILD_VARIANT),user)
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
     persist.sys.debug.multi_window=true
+endif


### PR DESCRIPTION
as mentioned on: https://android.googlesource.com/platform/packages/apps/Settings/+/4c9d667bc2044a5d5d0d0616425906f75b42a8e0
multiwindows option is hidden only on -user builds so there isn't needed to be defined on all builds.

Signed-off-by: David Viteri <davidteri91@gmail.com>