### PR TITLE
shinano: SELinux: Add mlog_qmi service

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -17,5 +17,6 @@
 /system/vendor/bin/sct_service                u:object_r:sct_exec:s0
 /system/vendor/bin/tad_static                 u:object_r:tad_exec:s0
 /system/vendor/bin/ta_qmi_service             u:object_r:ta_qmi_exec:s0
+/system/vendor/bin/mlog_qmi_service           u:object_r:mlog_qmi_exec:s0
 
 /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr    u:object_r:sysfs_addrsetup:s0

--- a/sepolicy/mlog_qmi.te
+++ b/sepolicy/mlog_qmi.te
@@ -1,0 +1,10 @@
+type mlog_qmi, domain;
+type mlog_qmi_exec, exec_type, file_type;
+
+# Started by init
+init_daemon_domain(mlog_qmi)
+
+allow mlog_qmi self:socket create_socket_perms;
+
+# Access to /dev/smem_log
+allow mlog_qmi smem_log_device:chr_file rw_file_perms;


### PR DESCRIPTION
[    9.967192] init: Warning!  Service mlog_qmi_service needs a SELinux domain defined; please fix!

Signed-off-by: David Viteri <davidteri91@gmail.com>