### PR TITLE
shinano: add SELinux for TFA amp service

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -123,6 +123,7 @@ BOARD_SEPOLICY_UNION += \
     addrsetup.te \
     device.te \
     file.te \
+    tfa_amp.te \
     property.te \
     sct.te \
     sensors.te \

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -4,6 +4,9 @@
 /dev/pn547                             u:object_r:nfc_device:s0
 /dev/pn54x                             u:object_r:nfc_device:s0
 
+/dev/tfa98xx                           u:object_r:audio_device:s0
+/system/bin/tfa9890_amp                u:object_r:tfa_amp_exec:s0
+
 # Block devices
 /dev/block/platform/msm_sdcc\.1/by-name/modemst1          u:object_r:modem_efs_partition_device:s0
 /dev/block/platform/msm_sdcc\.1/by-name/modemst2          u:object_r:modem_efs_partition_device:s0

--- a/sepolicy/tfa_amp.te
+++ b/sepolicy/tfa_amp.te
@@ -1,0 +1,8 @@
+type tfa_amp, domain;
+type tfa_amp_exec, exec_type, file_type;
+
+# Started by init
+init_daemon_domain(tfa_amp)
+
+# Access to /dev/tfa98xx
+allow tfa_amp audio_device:chr_file rw_file_perms;


### PR DESCRIPTION
[   10.893978] init: Warning!  Service tfa9890_amp needs a SELinux domain defined; please fix!

Signed-off-by: David Viteri <davidteri91@gmail.com>