### PR TITLE
Label bluetooth related files with their SELinux domain

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -136,5 +136,6 @@ BOARD_SEPOLICY_UNION += \
     thermanager.te \
     timekeep.te \
     file_contexts \
+    genfs_contexts \
     property_contexts \
     service_contexts

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,6 +1,9 @@
 # Trim Area daemon
 /dev/socket/tad                        u:object_r:tad_socket:s0
 
+# Bluetooth
+/dev/ttyHS0                            u:object_r:hci_attach_dev:s0
+
 /dev/pn547                             u:object_r:nfc_device:s0
 /dev/pn54x                             u:object_r:nfc_device:s0
 
@@ -26,3 +29,5 @@
 /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr    u:object_r:sysfs_addrsetup:s0
 /sys/devices/platform/bcmdhd_wlan/macaddr               u:object_r:sysfs_addrsetup:s0
 
+# Bluetooth
+/sys/devices/bluesleep.89/rfkill/rfkill0/state          u:object_r:sysfs_bluetooth_writable:s0

--- a/sepolicy/genfs_contexts
+++ b/sepolicy/genfs_contexts
@@ -1,0 +1,3 @@
+genfscon proc /bluetooth/sleep/lpm     u:object_r:proc_bluetooth_writable:s0
+genfscon proc /bluetooth/sleep/btwrite u:object_r:proc_bluetooth_writable:s0
+genfscon proc /bluetooth/sleep/proto   u:object_r:proc_bluetooth_writable:s0


### PR DESCRIPTION
Some files and devices are not labeled with their correct SELinux domain, which results in them being labeled with the default domain of that tree.