### PR TITLE
shinano: add system_server policy

### DIFF
--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -1,0 +1,1 @@
+allow system_server sysfs_addrsetup:file { getattr open read };


### PR DESCRIPTION
[  266.824989] type=1400 audit(1447450444.309:56): avc: denied { getattr } for pid=1284 comm=WifiStateMachin path=/sys/devices/platform/bcmdhd_wlan/macaddr dev=sysfs ino=12852 scontext=u:r:system_server:s0 tcontext=u:object_r:sysfs_addrsetup:s0 tclass=file permissive=1

[  266.825232] type=1400 audit(1447450444.309:57): avc: denied { read } for pid=1284 comm=WifiStateMachin name=macaddr dev=sysfs ino=12852 scontext=u:r:system_server:s0 tcontext=u:object_r:sysfs_addrsetup:s0 tclass=file permissive=1

[  266.825309] type=1400 audit(1447450444.309:58): avc: denied { open } for pid=1284 comm=WifiStateMachin path=/sys/devices/platform/bcmdhd_wlan/macaddr dev=sysfs ino=12852 scontext=u:r:system_server:s0 tcontext=u:object_r:sysfs_addrsetup:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>