### PR TITLE
shinano: remove vendor libs call

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -85,12 +85,7 @@ PRODUCT_PACKAGES += \
     audio.primary.msm8974 \
     audio.r_submix.default \
     audio.usb.default \
-    libaudio-resampler \
-    libacdbloader \
-    libacdbmapper \
-    libaudcal \
-    libaudioalsa \
-    libdiag
+    libaudio-resampler
 
 # For audio.primary.msm8974
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
those are part of vendor zip libs and they are not needed here

Signed-off-by: David Viteri <davidteri91@gmail.com>