### PR TITLE
shinano: add wpa policy

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -135,6 +135,7 @@ BOARD_SEPOLICY_UNION += \
     ta_qmi.te \
     thermanager.te \
     timekeep.te \
+    wpa.te \
     file_contexts \
     genfs_contexts \
     property_contexts \

--- a/sepolicy/wpa.te
+++ b/sepolicy/wpa.te
@@ -1,0 +1,1 @@
+allow wpa sysfs_addrsetup:file { getattr open read };


### PR DESCRIPTION
<38>[   21.742870] type=1400 audit(1448009566.349:11): avc: denied { getattr } for pid=1229 comm=wpa_supplicant path=/sys/devices/platform/bcmdhd_wlan/macaddr dev=sysfs ino=12852 scontext=u:r:wpa:s0 tcontext=u:object_r:sysfs_addrsetup:s0 tclass=file permissive=1

<38>[   21.743124] type=1400 audit(1448009566.349:12): avc: denied { read } for pid=1229 comm=wpa_supplicant name=macaddr dev=sysfs ino=12852 scontext=u:r:wpa:s0 tcontext=u:object_r:sysfs_addrsetup:s0 tclass=file permissive=1

<38>[   21.743247] type=1400 audit(1448009566.349:13): avc: denied { open } for pid=1229 comm=wpa_supplicant path=/sys/devices/platform/bcmdhd_wlan/macaddr dev=sysfs ino=12852 scontext=u:r:wpa:s0 tcontext=u:object_r:sysfs_addrsetup:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>