### PR TITLE
shinano: allow untrusted apps to thermanager

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -135,6 +135,7 @@ BOARD_SEPOLICY_UNION += \
     ta_qmi.te \
     thermanager.te \
     timekeep.te \
+    untrusted_app.te \
     wpa.te \
     file_contexts \
     genfs_contexts \

--- a/sepolicy/untrusted_app.te
+++ b/sepolicy/untrusted_app.te
@@ -1,0 +1,1 @@
+allow untrusted_app thermanager_exec:file { getattr read };


### PR DESCRIPTION
11-21 19:12:12.410: I/IntentService[S(5853): type=1400 audit(0.0:201): avc: denied { getattr } for path=/system/bin/thermanager dev=mmcblk0p23 ino=355 scontext=u:r:untrusted_app:s0 tcontext=u:object_r:thermanager_exec:s0 tclass=file permissive=1
11-21 19:12:12.410: I/IntentService[S(5853): type=1400 audit(0.0:202): avc: denied { read } for name=thermanager dev=mmcblk0p23 ino=355 scontext=u:r:untrusted_app:s0 tcontext=u:object_r:thermanager_exec:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>