### PR TITLE
shinano: add policy for new USB drivers

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -36,3 +36,6 @@
 
 # Bluetooth
 /sys/devices/bluesleep.89/rfkill/rfkill0/state          u:object_r:sysfs_bluetooth_writable:s0
+
+# USB & Power
+/sys/devices/msm_dwc3/power_supply/usb/type             u:object_r:sysfs_usb_supply:s0

--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -1,2 +1,3 @@
 allow system_server sysfs_addrsetup:file { getattr open read };
 allow system_server init:unix_stream_socket { getopt };
+allow system_server sysfs_usb_supply:file { getattr open read };


### PR DESCRIPTION
11-26 15:32:36.945  1131  1131 I Binder_3: type=1400 audit(0.0:7): avc: denied { read } for name=type dev=sysfs ino=13174 scontext=u:r:system_server:s0 tcontext=u:object_r:sysfs_usb_supply:s0 tclass=file permissive=1
> 11-26 15:32:36.945  1131  1131 I Binder_3: type=1400 audit(0.0:8): avc: denied { open } for path=/sys/devices/msm_dwc3/power_supply/usb/type dev=sysfs ino=13174 scontext=u:r:system_server:s0 tcontext=u:object_r:sysfs_usb_supply:s0 tclass=file permissive=1
> 11-26 15:32:36.945  1131  1131 I Binder_3: type=1400 audit(0.0:9): avc: denied { getattr } for path=/sys/devices/msm_dwc3/power_supply/usb/type dev=sysfs ino=13174 scontext=u:r:system_server:s0 tcontext=u:object_r:sysfs_usb_supply:s0 tclass=file permissive=1
>
> Signed-off-by: David Viteri <davidteri91@gmail.com>