### PR TITLE
shinano: update system_server.te

### DIFF
--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -1,3 +1,4 @@
 allow system_server sysfs_addrsetup:file { getattr open read };
 allow system_server init:unix_stream_socket { getopt };
 allow system_server sysfs_usb_supply:file { getattr open read };
+allow system_server sysfs_usb_supply:dir { search };


### PR DESCRIPTION
avoid

[   30.756958] type=1400 audit(1448553323.159:6): avc: denied { search } for pid=887 comm=ActivityManager name=usb dev=sysfs ino=13163 scontext=u:r:system_server:s0 tcontext=u:object_r:sysfs_usb_supply:s0 tclass=dir permissive=1
[   36.123415] type=1400 audit(1448553328.529:7): avc: denied { search } for pid=1644 comm=Binder_9 name=usb dev=sysfs ino=13163 scontext=u:r:system_server:s0 tcontext=u:object_r:sysfs_usb_supply:s0 tclass=dir permissive=1
[  246.138806] type=1400 audit(1448553538.058:9): avc: denied { search } for pid=1639 comm=Binder_7 name=usb dev=sysfs ino=13163 scontext=u:r:system_server:s0 tcontext=u:object_r:sysfs_usb_supply:s0 tclass=dir permissive=1
[  396.126042] type=1400 audit(1448553688.058:14): avc: denied { search } for pid=882 comm=Binder_2 name=usb dev=sysfs ino=13163 scontext=u:r:system_server:s0 tcontext=u:object_r:sysfs_usb_supply:s0 tclass=dir permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>