### PR TITLE
shinano: decrease the display brightness at the startup

### DIFF
--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -19,6 +19,9 @@ on early-init
     mount debugfs debugfs /sys/kernel/debug
 
 on init
+    # decrease the display brightness at the startup (actually set to 4095)
+    write /sys/class/leds/lcd-backlight/brightness 2047
+
     # Support legacy libs
     symlink /system/vendor/lib/egl /egl
 


### PR DESCRIPTION
Actually the brightness is too high.. with this we can have a good level and prevent battery drain

Signed-off-by: David Viteri <davidteri91@gmail.com>