### PR TITLE
[TEMP] shinano: disable build keystore.msm8974

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -156,15 +156,16 @@ PRODUCT_PACKAGES += \
     wpa_supplicant.conf
 
 
-#CAMERA
+# CAMERA
 PRODUCT_PACKAGES += \
     libmmcamera_interface \
     libmmjpeg_interface \
     libqomx_core \
     camera.msm8974
 
-PRODUCT_PACKAGES += \
-    keystore.msm8974
+# Keystore
+# PRODUCT_PACKAGES += \
+#     keystore.msm8974
 
 # Misc
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
It is causing FC when enter to settings - security options and soft reboots when unnistall an app

Signed-off-by: David Viteri <davidteri91@gmail.com>

@jerpelea probably the same is needed on 8226 due to 8994 has not this problem ..... and I can't check on 8226 device due to missing targets