### PR TITLE
shinano: Add TARGET_REQUIRES_B64_COMPAT

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -52,6 +52,9 @@ BOARD_FLASH_BLOCK_SIZE := 131072 # (BOARD_KERNEL_PAGESIZE * 64)
 
 TARGET_RECOVERY_FSTAB = device/sony/shinano/rootdir/fstab.shinano
 
+# BoringSSL
+TARGET_REQUIRES_B64_COMPAT := true
+
 # GFX
 USE_OPENGL_RENDERER := true
 TARGET_USES_ION := true


### PR DESCRIPTION
Adreno requires it for BoringSSL loading.

Fixed:
    dlopen failed: cannot locate symbol "BIO_f_base64"
        referenced by "/system/vendor/lib/egl/libEGL_adreno.so"...

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ieae17bd54c63d758f18801e04e244e944f1b0883