### PR TITLE
shinano: sepolicy: Fix bluetooth denials

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -36,6 +36,9 @@
 
 # Bluetooth
 /sys/devices/bluesleep.89/rfkill/rfkill0/state          u:object_r:sysfs_bluetooth_writable:s0
+/proc/bluetooth/sleep/proto                             u:object_r:sysfs_bluetooth_writable:s0
+/proc/bluetooth/sleep/lpm                               u:object_r:sysfs_bluetooth_writable:s0
+/proc/bluetooth/sleep/btwrite                           u:object_r:sysfs_bluetooth_writable:s0
 
 # USB & Power
 /sys/devices/msm_dwc3/power_supply/usb/type             u:object_r:sysfs_usb_supply:s0


### PR DESCRIPTION
set bluesleep files as sysfs_bluetooth_writable

Fix:
[   36.115517] type=1400 audit(1450813677.282:254): avc: denied { write } for pid=2613 comm=626C756564726F69642077616B652F name="lpm" dev="proc" ino=4026544871 scontext=u:r:bluetooth:s0 tcontext=u:object_r:proc:s0 tclass=file permissive=1

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I3894df4143447835de6df6a40efebef4621c2f2a