### PR TITLE
shinano: update system_server.te

### DIFF
--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -2,3 +2,4 @@ allow system_server sysfs_addrsetup:file { getattr open read };
 allow system_server init:unix_stream_socket { getopt };
 allow system_server sysfs_usb_supply:file { getattr open read };
 allow system_server sysfs_usb_supply:dir { search };
+allow system_server recovery_cache_file:dir { rmdir };


### PR DESCRIPTION
Avoid

[  235.873031] type=1400 audit(1451155335.279:4): avc: denied { rmdir } for pid=2652 comm=Thread-252 name=fota dev=mmcblk0p24 ino=6410 scontext=u:r:system_server:s0 tcontext=u:object_r:recovery_cache_file:s0 tclass=dir permissive=0

[  373.883716] type=1400 audit(1451155474.258:7): avc: denied { rmdir } for pid=5771 comm=Thread-220 name=fota dev=mmcblk0p24 ino=6410 scontext=u:r:system_server:s0 tcontext=u:object_r:recovery_cache_file:s0 tclass=dir permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>