### PR TITLE
PowerHAL: AOSP does not set the governor perms

### DIFF
--- a/rootdir/init.shinano.pwr.rc
+++ b/rootdir/init.shinano.pwr.rc
@@ -79,3 +79,20 @@ on property:init.svc.bootanim=stopped
 
     # Enable thermal
     write /sys/module/msm_thermal/core_control/enabled 1
+
+    # Simple PowerHAL: AOSP does not set the governor perms
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/above_hispeed_delay
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/align_windows
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/boost
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/boostpulse
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/boostpulse_duration
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/go_hispeed_load
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/hispeed_freq
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/io_is_busy
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/max_freq_hysteresis
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/min_sample_time
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/target_loads
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/timer_rate
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/timer_slack
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/use_migration_notif
+    chown system system /sys/devices/system/cpu/cpufreq/interactive/use_sched_load


### PR DESCRIPTION
Many other custom ROMs set this automatically

Signed-off-by: Adam Farden <adam@farden.cz>