### PR TITLE
shinano: add policy for more denials

### DIFF
--- a/sepolicy/system_app.te
+++ b/sepolicy/system_app.te
@@ -1,1 +1,2 @@
 allow system_app timekeep_prop:property_service set;
+allow system_app system_data_file:dir { add_name create setattr };


### PR DESCRIPTION
Avoid

[  652.214267] type=1400 audit(1452457241.198:14): avc: granted { add_name } for pid=6019 comm=system:ui name=cache scontext=u:r:system_app:s0 tcontext=u:object_r:system_data_file:s0 tclass=dir

[  652.235670] type=1400 audit(1452457241.198:15): avc: granted { create } for pid=6019 comm=system:ui name=cache scontext=u:r:system_app:s0 tcontext=u:object_r:system_data_file:s0 tclass=dir

[  652.261785] type=1400 audit(1452457241.198:16): avc: granted { setattr } for pid=6019 comm=system:ui name=cache dev=mmcblk0p25 ino=390970 scontext=u:r:system_app:s0 tcontext=u:object_r:system_data_file:s0 tclass=dir

Signed-off-by: David Viteri <davidteri91@gmail.com>