### PR TITLE
shinano: update init.te

### DIFF
--- a/sepolicy/init.te
+++ b/sepolicy/init.te
@@ -29,3 +29,4 @@ allow init uio_device:chr_file write;
 allow init sysfs_wake_lock:file { getattr };
 allow init sysfs_usb_supply:file { getattr };
 allow init sysfs_usb_supply:lnk_file { read getattr };
+allow init mtp_device:chr_file { getattr };


### PR DESCRIPTION
Avoid

01-13 09:27:31.610 I/toolbox (4126): type=1400 audit(0.0:31): avc: denied { getattr } for path=/dev/mtp_usb dev=tmpfs ino=8001 scontext=u:r:init:s0 tcontext=u:object_r:mtp_device:s0 tclass=chr_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>