### PR TITLE
shinano: Move NFC HAL build name to device

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -132,8 +132,7 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     com.android.nfc_extras \
     NfcNci \
-    Tag \
-    nfc_nci.msm8974
+    Tag
 
 # GPS
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Signed-off-by: Humberto Borba <humberos@gmail.com>