### PR TITLE
shinano: set /cache and /data partitions as formattable

### DIFF
--- a/rootdir/fstab.shinano
+++ b/rootdir/fstab.shinano
@@ -3,8 +3,8 @@
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
 /dev/block/platform/msm_sdcc.1/by-name/system       /system           ext4    ro,barrier=1                                                  wait
-/dev/block/platform/msm_sdcc.1/by-name/cache        /cache            ext4    noatime,nosuid,nodev,barrier=1,data=ordered                   wait,check
-/dev/block/platform/msm_sdcc.1/by-name/userdata     /data             ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc   wait,check,encryptable=footer
+/dev/block/platform/msm_sdcc.1/by-name/cache        /cache            ext4    noatime,nosuid,nodev,barrier=1,data=ordered                   wait,check,formattable
+/dev/block/platform/msm_sdcc.1/by-name/userdata     /data             ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc   wait,check,formattable,encryptable=footer
 /dev/block/platform/msm_sdcc.1/by-name/boot         /boot             emmc    defaults                                                      defaults
 /dev/block/platform/msm_sdcc.1/by-name/FOTAKernel   /recovery         emmc    defaults                                                      defaults
 /devices/msm_sdcc.2/mmc_host*                       auto              auto    defaults                                                      voldmanaged=sdcard1:auto,encryptable=userdata


### PR DESCRIPTION
very useful on modding specially with newer custom recoveries as CM or TWRP

Signed-off-by: David Viteri <davidteri91@gmail.com>