### PR TITLE
shinano: init: Use predefined readahead values from kernel

### DIFF
--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -96,10 +96,6 @@ on early-boot
     setrlimit 8 67108864 67108864
 
 on boot
-    # Read ahead buffer
-    write /sys/block/mmcblk0/queue/read_ahead_kb 512
-    write /sys/block/mmcblk1/queue/read_ahead_kb 512
-
     # PM8941 flash
     chown media system /sys/class/misc/pm8941-flash/device/current1
     chown media system /sys/class/misc/pm8941-flash/device/current2


### PR DESCRIPTION
readahead values:
https://github.com/sonyxperiadev/kernel/commit/02246eebb459560296a163529f22ffb724ccaa30

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I521e628c5efcd53fa85eaa27ae2dbdc4a27f9dbb