### PR TITLE
fstab: fix external storage path

### DIFF
--- a/rootdir/fstab.shinano
+++ b/rootdir/fstab.shinano
@@ -7,5 +7,5 @@
 /dev/block/platform/msm_sdcc.1/by-name/cache        /cache       ext4    nosuid,nodev,discard                             wait,check
 /dev/block/platform/msm_sdcc.1/by-name/boot         /boot        emmc    defaults                                         defaults
 /dev/block/platform/msm_sdcc.1/by-name/FOTAKernel   /recovery    emmc    defaults                                         defaults
-/devices/msm_sdcc.2/mmc_host*                       auto         auto    defaults                                         voldmanaged=sdcard1:auto,noemulatedsd
+/devices/msm_sdcc.*/mmc_host*                       auto         auto    defaults                                         voldmanaged=sdcard1:auto,noemulatedsd
 /devices/*/xhci-hcd.0.auto/usb*                     auto         auto    defaults                                         voldmanaged=usbdisk:auto


### PR DESCRIPTION
to handle the different paths for wifi and sdcard between scorpion and
other shinano devices, add all msm_sdcc using the wildcard and let fstab
check for existence