### PR TITLE
shinano: recovery: Add /dev/block/bootdevice symlink

### DIFF
--- a/rootdir/init.recovery.shinano.rc
+++ b/rootdir/init.recovery.shinano.rc
@@ -1,3 +1,6 @@
+on init
+    symlink /dev/block/platform/soc.0/f9824900.sdhci /dev/block/bootdevice
+
 on boot
     write /sys/class/android_usb/android0/idVendor 0FCE
     write /sys/class/android_usb/android0/idProduct 6${ro.usb.pid_suffix}


### PR DESCRIPTION
It is required for partitions mounting process.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I6a8123e6a818c98ea51b0f22574cc70aef585fa3