### PR TITLE
shinano: recovery: Fix block path

### DIFF
--- a/rootdir/init.recovery.shinano.rc
+++ b/rootdir/init.recovery.shinano.rc
@@ -1,5 +1,5 @@
 on init
-    symlink /dev/block/platform/soc.0/f9824900.sdhci /dev/block/bootdevice
+    symlink /dev/block/platform/msm_sdcc.1 /dev/block/bootdevice
 
 on boot
     write /sys/class/android_usb/android0/idVendor 0FCE


### PR DESCRIPTION
this is the correct path for shinano devices.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I78d57efb474425bc3ea0c19276b8ff885b656993