### PR TITLE
NFC: Add back lost symlink

### DIFF
--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -52,6 +52,7 @@ on boot
     chmod 0660 /proc/bluetooth/sleep/btwrite
 
     # Symlink for compability
+    symlink /dev/pn54x /dev/pn544
     symlink /dev/pn54x /dev/pn547
 
 # TFA AMP


### PR DESCRIPTION
HAL is hardwired to look at pn544

Signed-off-by: Adam Farden <adam@farden.cz>