### PR TITLE
shinano: ueventd: Add common lights sysfs path

### DIFF
--- a/rootdir/ueventd.shinano.rc
+++ b/rootdir/ueventd.shinano.rc
@@ -122,6 +122,8 @@
 /sys/devices/01-qcom,leds-d000/leds/led:* ramp_step_ms            0664 system system
 /sys/devices/01-qcom,leds-d800/leds/wled:backlight max_brightness 0664 system system
 /sys/devices/01-qcom,leds-d800/leds/wled:backlight brightness     0664 system system
+/sys/class/leds/lcd-backlight/max_brightness                      0644 root system
+/sys/class/leds/lcd-backlight/brightness                          0664 system system
 
 # IR Remote
 /dev/ttyHSL1                                   0660 system system


### PR DESCRIPTION
Since lights HAL is unified then all platforms
should be set this permission for system.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I1d4e3d6b43a44217a016b877c9686eebdac91ef2