### PR TITLE
shinano: re-add media_codecs_performance.xml

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -23,6 +23,7 @@ SONY_ROOT := device/sony/shinano/rootdir
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/system/etc/audio_platform_info.xml:system/etc/audio_platform_info.xml \
     $(SONY_ROOT)/system/etc/media_codecs.xml:system/etc/media_codecs.xml \
+    $(SONY_ROOT)/system/etc/media_codecs_performance.xml:system/etc/media_codecs_performance.xml \
     $(SONY_ROOT)/system/etc/media_profiles.xml:system/etc/media_profiles.xml
 
 # Broadcom BT

--- a/rootdir/system/etc/media_codecs_performance.xml
+++ b/rootdir/system/etc/media_codecs_performance.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2015 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<MediaCodecs>
+    <Encoders>
+        <MediaCodec name="OMX.qcom.video.encoder.avc" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="477-477" />
+            <Limit name="measured-frame-rate-720x480" range="173-173" />
+            <Limit name="measured-frame-rate-1280x720" range="75-75" />
+            <Limit name="measured-frame-rate-1920x1080" range="37-37" />
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.encoder.h263" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="403-403" />
+            <Limit name="measured-frame-rate-352x288" range="319-319" />
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.encoder.mpeg4" type="video/mp4v-es" update="true">
+            <Limit name="measured-frame-rate-176x144" range="440-440" />
+            <Limit name="measured-frame-rate-352x288" range="331-331" />
+            <Limit name="measured-frame-rate-640x480" range="179-179" />
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.encoder.vp8" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="125-125" />
+            <Limit name="measured-frame-rate-640x360" range="193-193" />
+            <Limit name="measured-frame-rate-1280x720" range="74-74" />
+            <Limit name="measured-frame-rate-1920x1080" range="36-36" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.h264.encoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="498-498" />
+            <Limit name="measured-frame-rate-720x480" range="156-156" />
+            <Limit name="measured-frame-rate-1280x720" range="66-66" />
+            <Limit name="measured-frame-rate-1920x1080" range="31-31" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.h263.encoder" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="634-634" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.mpeg4.encoder" type="video/mp4v-es" update="true">
+            <Limit name="measured-frame-rate-176x144" range="896-896" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.vp8.encoder" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="600-600" />
+            <Limit name="measured-frame-rate-640x360" range="230-230" />
+            <Limit name="measured-frame-rate-1280x720" range="64-64" />
+            <Limit name="measured-frame-rate-1920x1080" range="26-26" />
+        </MediaCodec>
+    </Encoders>
+    <Decoders>
+        <MediaCodec name="OMX.qcom.video.decoder.avc" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="208-208" />
+            <Limit name="measured-frame-rate-720x480" range="178-178" />
+            <Limit name="measured-frame-rate-1280x720" range="87-87" />
+            <Limit name="measured-frame-rate-1920x1088" range="48-48" />
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.h263" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="513-513" />
+            <Limit name="measured-frame-rate-352x288" range="474-474" />
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.mpeg4" type="video/mp4v-es" update="true">
+            <Limit name="measured-frame-rate-480x360" range="426-426" />
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.vp8" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="634-634" />
+            <Limit name="measured-frame-rate-640x360" range="601-601" />
+            <Limit name="measured-frame-rate-1280x720" range="567-567" />
+            <Limit name="measured-frame-rate-1920x1080" range="319-319" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.h264.decoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="832-832" />
+            <Limit name="measured-frame-rate-720x480" range="359-359" />
+            <Limit name="measured-frame-rate-1280x720" range="173-173" />
+            <Limit name="measured-frame-rate-1920x1080" range="55-55" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.h263.decoder" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="1939-1939" />
+            <Limit name="measured-frame-rate-352x288" range="1232-1232" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.hevc.decoder" type="video/hevc" update="true">
+            <Limit name="measured-frame-rate-352x288" range="680-680" />
+            <Limit name="measured-frame-rate-640x360" range="442-442" />
+            <Limit name="measured-frame-rate-1280x720" range="190-190" />
+            <Limit name="measured-frame-rate-1920x1080" range="91-91" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.vp8.decoder" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="951-951" />
+            <Limit name="measured-frame-rate-640x360" range="374-374" />
+            <Limit name="measured-frame-rate-1280x720" range="117-117" />
+            <Limit name="measured-frame-rate-1920x1080" range="77-77" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.vp9.decoder" type="video/x-vnd.on2.vp9" update="true">
+            <Limit name="measured-frame-rate-320x180" range="421-421" />
+            <Limit name="measured-frame-rate-640x360" range="347-347" />
+            <Limit name="measured-frame-rate-1280x720" range="111-111" />
+            <Limit name="measured-frame-rate-1920x1080" range="70-70" />
+        </MediaCodec>
+    </Decoders>
+</MediaCodecs>


### PR DESCRIPTION
this was removed durin device-sony-common repo also is needed by system

log:

MediaCodecList: Unable to open media codecs configuration xml file: /data/misc/media/media_cedecs_profiling_results.xml

Signed-off-by: David Viteri <davidteri91@gmail.com>