### PR TITLE
shinano: Fix simple power HAL permissions

### DIFF
--- a/rootdir/init.shinano.pwr.rc
+++ b/rootdir/init.shinano.pwr.rc
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+on init
+    # cpuquiet rqbalance permissions
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
+
 on charger
     # Enable Power modes and set the CPU Freq Sampling rates
     write /sys/module/msm_thermal/core_control/enabled 0
@@ -52,14 +61,6 @@ on boot
     write /sys/devices/system/cpu/cpu1/online 1
     write /sys/devices/system/cpu/cpu2/online 1
     write /sys/devices/system/cpu/cpu3/online 1
-
-    # cpuquiet rqbalance permissions
-    chown root system /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
-    chown root system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
-    chown root system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
-    chmod 664 /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
-    chmod 664 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
-    chmod 664 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
 
 on property:init.svc.bootanim=stopped
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "interactive"

--- a/rootdir/ueventd.shinano.rc
+++ b/rootdir/ueventd.shinano.rc
@@ -149,6 +149,6 @@
 /sys/devices/virtual/graphics/fb2/ad                  0664 system graphics
 
 # cpuquiet rqbalance permissions
-/sys/devices/system/cpu/cpuquiet/rqbalance/balance_level             0664 root system
-/sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds         0664 root system
-/sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds    0664 root system
+/sys/devices/system/cpu/cpuquiet/rqbalance/balance_level             0660 system system
+/sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds         0660 system system
+/sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds    0660 system system


### PR DESCRIPTION
Fix and move simple power HAL permissions to "on init" stage
then it will also be able early to LPM mode.

Change-Id: Ibc882eaaca0dc7431f9ca722e879a0091c16bdfe
Signed-off-by: Humberto Borba <humberos@gmail.com>