### PR TITLE
Remove obsolete global flags

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -18,8 +18,6 @@ TARGET_BOARD_PLATFORM := msm8974
 TARGET_CPU_ABI := armeabi-v7a
 TARGET_CPU_ABI2 := armeabi
 TARGET_CPU_VARIANT := krait
-TARGET_GLOBAL_CFLAGS += -mfpu=neon -mfloat-abi=softfp
-TARGET_GLOBAL_CPPFLAGS += -mfpu=neon -mfloat-abi=softfp
 
 BOARD_KERNEL_BASE        := 0x00000000
 BOARD_KERNEL_PAGESIZE    := 2048


### PR DESCRIPTION
They have been hrmless up to Marshmallow but now they cause conflicts:

out/soong/make_vars-aosp_d6503.mk:202: TARGET_GLOBAL_CFLAGS does not match between Make and Soong:
out/soong/make_vars-aosp_d6503.mk:202: Make  adds:
out/soong/make_vars-aosp_d6503.mk:202: Soong adds: -DANDROID -DNDEBUG -D_FORTIFY_SOURCE=2 -D__ARM_FEATURE_LPAE=1 -UDEBUG -W -Wa,--noexecstack -Wall -Werror=address -Werror=date-time -Werror=format-security -Werror=non-virtual-dtor -Werror=return-type -Werror=sequence-point -Winit-self -Wno-multichar -Wno-unused -Wpointer-arith -Wstrict-aliasing=2 -fdata-sections -fdebug-prefix-map=/proc/self/cwd= -fdiagnostics-color -ffunction-sections -fgcse-after-reload -fmessage-length=0 -fno-builtin-sin -fno-canonical-system-headers -fno-exceptions -fno-short-enums -fno-strict-volatile-bitfields -frename-registers -frerun-cse-after-loop -fstack-protector-strong -funwind-tables -g -mcpu=cortex-a15 -msoft-float -mthumb-interwork -no-canonical-prefixes

out/soong/make_vars-aosp_d6503.mk:208: TARGET_GLOBAL_CPPFLAGS does not match between Make and Soong:
out/soong/make_vars-aosp_d6503.mk:208: Make  adds: -mfloat-abi=softfp -mfpu=neon
out/soong/make_vars-aosp_d6503.mk:208: Soong adds: -Wsign-promo -fvisibility-inlines-hidden

out/soong/make_vars-aosp_d6503.mk:254: *** Soong variable check failed.
build/core/ninja.mk:161: recipe for target 'out/build-aosp_d6503-dist.ninja' failed
make: *** [out/build-aosp_d6503-dist.ninja] Error 1

Signed-off-by: Adam Farden <adam@farden.cz>