### PR TITLE
[master] sony: shinano: Set BT default name dynamically

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -17,6 +17,37 @@
 #ifndef _BDROID_BUILDCFG_H
 #define _BDROID_BUILDCFG_H
 
+#if !defined(OS_GENERIC)
+#include <cutils/properties.h>
+#include <string.h>
+
+static inline const char* getBTDefaultName()
+{
+    char device[PROPERTY_VALUE_MAX];
+    property_get("ro.boot.hardware", device, "");
+
+    if (!strcmp("sirius", device)) {
+        return "Xperia Z2";
+    } else if (!strcmp("castor", device)) {
+        return "Xperia Z2 Tablet";
+    } else if (!strcmp("castor_windy", device)) {
+        return "Xperia Z2 Tablet";
+    } else if (!strcmp("leo", device)) {
+        return "Xperia Z3";
+    } else if (!strcmp("aries", device)) {
+        return "Xperia Z3 Compact";
+    } else if (!strcmp("scorpion", device)) {
+        return "Xperia Z3 Tablet";
+    } else if (!strcmp("scorpion_windy", device)) {
+        return "Xperia Z3 Tablet";
+    }
+
+    return "Xperia";
+}
+
+#define BTM_DEF_LOCAL_NAME getBTDefaultName()
+#endif // OS_GENERIC
+
 /* #define BTA_AV_CO_CP_SCMS_T   TRUE */
 #define SDP_AVRCP_1_5   FALSE
 


### PR DESCRIPTION
Use ro.boot.hardware property and naming BT dynamically.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Iff4f4dd51a2ad5588e35c14dbf70b63e1d69a940