### PR TITLE
shinano: Fix LED paths for kernel 1.3.3

### DIFF
--- a/rootdir/ueventd.shinano.rc
+++ b/rootdir/ueventd.shinano.rc
@@ -116,13 +116,13 @@
 /sys/devices/f9928000.i2c/i2c-6/6-0028  send_cmd    0200 nfc nfc
 
 # LED
-/sys/devices/01-qcom,leds-d000/leds/led:* max_brightness          0664 system system
-/sys/devices/01-qcom,leds-d000/leds/led:* brightness              0664 system system
-/sys/devices/01-qcom,leds-d000/leds/led:* blink                   0664 system system
-/sys/devices/01-qcom,leds-d000/leds/led:* duty_pcts               0664 system system
-/sys/devices/01-qcom,leds-d000/leds/led:* ramp_step_ms            0664 system system
-/sys/devices/01-qcom,leds-d800/leds/wled:backlight max_brightness 0664 system system
-/sys/devices/01-qcom,leds-d800/leds/wled:backlight brightness     0664 system system
+/sys/devices/01-qcom,leds-0x0000d000/leds/led:* max_brightness          0664 system system
+/sys/devices/01-qcom,leds-0x0000d000/leds/led:* brightness              0664 system system
+/sys/devices/01-qcom,leds-0x0000d000/leds/led:* blink                   0664 system system
+/sys/devices/01-qcom,leds-0x0000d000/leds/led:* duty_pcts               0664 system system
+/sys/devices/01-qcom,leds-0x0000d000/leds/led:* ramp_step_ms            0664 system system
+/sys/devices/01-qcom,leds-0x0000d800/leds/wled:backlight max_brightness 0664 system system
+/sys/devices/01-qcom,leds-0x0000d800/leds/wled:backlight brightness     0664 system system
 /sys/class/leds/lcd-backlight/max_brightness                      0644 root system
 /sys/class/leds/lcd-backlight/brightness                          0664 system system
 


### PR DESCRIPTION
From 1.2.2 to 1.3.3 the LED path changed, as @alviteri pointed out.