### PR TITLE
[SHINANO] system.prop: Tune rqbalance parameters

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -8,8 +8,8 @@ rqbalance.low.balance_level=80
 rqbalance.low.up_threshold=200 400 600 4294967295
 rqbalance.low.down_threshold=0 100 300 500
 
-cpuquiet.normal.min_cpus=1
+cpuquiet.normal.min_cpus=2
 cpuquiet.normal.max_cpus=4
 rqbalance.normal.balance_level=40
-rqbalance.normal.up_threshold=100 200 300 4294967295
-rqbalance.normal.down_threshold=0 50 150 250
+rqbalance.normal.up_threshold=100 250 330 4294967295
+rqbalance.normal.down_threshold=0 130 220 300


### PR DESCRIPTION
Tune rqbalance to linearize CPU hotplugging and	optimize power
consumption while retaining performance.