### PR TITLE
shinano: use lz4 compression for ZRAM

### DIFF
--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -18,6 +18,8 @@ import init.shinano.pwr.rc
 
 on init
     symlink /dev/block/platform/msm_sdcc.1 /dev/block/bootdevice
+    # Use LZ4 compression for ZRAM
+    write /sys/block/zram0/comp_algorithm lz4
 
 on fs
     mount_all ./fstab.shinano


### PR DESCRIPTION
Use lz4 compression method instead of the default lzo zram compression. Might have better performance.
See here for more details: https://github.com/torvalds/linux/commit/6e76668e415adf799839f0ab205142ad7002d260