### PR TITLE
Fix Bluetooth MAC-Adress read from /data/misc

### DIFF
--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -25,8 +25,12 @@ on fs
     write /sys/kernel/boot_adsp/boot 1
 
 on boot
-    # Bluetooth
+    # WLAN
     chown system system /sys/devices/platform/bcmdhd_wlan/macaddr
+    
+    # Bluetooth
+    chown system system /data/misc/bluetooth/bluetooth_bdaddr
+    chmod 660 /data/misc/bluetooth/bluetooth_bdaddr
 
     # Cover mode
     chown system system /sys/devices/virtual/input/clearpad/cover_mode_enabled


### PR DESCRIPTION
If the fix is not present, the device will kill macaddrsetup and you will get a new bluetooth and wlan mac adress every time you reboot