### PR TITLE
Revert "Fix Bluetooth MAC-Adress read from /data/misc"

### DIFF
--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -25,12 +25,8 @@ on fs
     write /sys/kernel/boot_adsp/boot 1
 
 on boot
-    # WLAN
-    chown system system /sys/devices/platform/bcmdhd_wlan/macaddr
-    
     # Bluetooth
-    chown system system /data/misc/bluetooth/bluetooth_bdaddr
-    chmod 660 /data/misc/bluetooth/bluetooth_bdaddr
+    chown system system /sys/devices/platform/bcmdhd_wlan/macaddr
 
     # Cover mode
     chown system system /sys/devices/virtual/input/clearpad/cover_mode_enabled


### PR DESCRIPTION
Reverts sonyxperiadev/device-sony-shinano#314

the folder had bluetooth permissions and this change is noy needed