### PR TITLE
fstab: Allow recovery to use the misc partition

### DIFF
--- a/rootdir/fstab.shinano
+++ b/rootdir/fstab.shinano
@@ -7,6 +7,7 @@
 /dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,discard,errors=panic wait,check,formattable,encryptable=footer
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
+/dev/block/bootdevice/by-name/apps_log     /misc        emmc    defaults                                                      defaults
 
 /devices/msm_sdcc.*/mmc_host/mmc2*         auto         auto    defaults                                                      voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/*/xhci-hcd.0.auto/usb*            auto         auto    defaults                                                      voldmanaged=usb:auto


### PR DESCRIPTION
Android Nougat changed how it communicates with the recovery
partition. Until now the recovery commands had been written
to the /cache partition, but this has changed. Now recovery
writes to the /misc partition.

Fortunately for shinano devices we actually have
an empty and unused /apps_log partition we can use.

NOTE: avoid

      E:Cannot load volume /misc!
      checked on Marshmallow recovery

Signed-off-by: Adam Farden <adam@farden.cz>
Signed-off-by: David Viteri <davidteri91@gmail.com>