### PR TITLE
shinano: enable legacy camera fixes

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -46,6 +46,9 @@ BOARD_FLASH_BLOCK_SIZE := 131072 # (BOARD_KERNEL_PAGESIZE * 64)
 
 TARGET_RECOVERY_FSTAB = $(PLATFORM_COMMON_PATH)/rootdir/fstab.shinano
 
+# Camera HAL1 hack on 7.x
+TARGET_HAS_LEGACY_CAMERA_HAL1 := true
+
 # Wi-Fi definitions for Broadcom solution
 BOARD_WLAN_DEVICE           := bcmdhd
 BOARD_WPA_SUPPLICANT_DRIVER := NL80211

--- a/platform.mk
+++ b/platform.mk
@@ -89,6 +89,11 @@ PRODUCT_PACKAGES += \
     brcm-uim-sysfs \
     libfmjni
 
+# Camera HAL1 hack on 7.x
+PRODUCT_PROPERTY_OVERRIDES += \
+    media.stagefright.legacyencoder=true \
+    media.stagefright.less-secure=true
+
 # RILD
 PRODUCT_PROPERTY_OVERRIDES += \
     rild.libpath=/vendor/lib/libril-qc-qmi-1.so \


### PR DESCRIPTION
Signed-off-by: David Viteri <davidteri91@gmail.com>

Needed by people working with 7.1.1 under kernel 3.10