### PR TITLE
shinano: let cameraHAL to limit FPS on 15

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -94,6 +94,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
     media.stagefright.legacyencoder=true \
     media.stagefright.less-secure=true
 
+# Cam FPS
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.debug.set.fixedfps=15
+
 # RILD
 PRODUCT_PROPERTY_OVERRIDES += \
     rild.libpath=/vendor/lib/libril-qc-qmi-1.so \


### PR DESCRIPTION
Some apps are requesting 30FPS for camera here
12-25 20:43:59.499   413  5552 I mm-camera: sensor_set_resolution:2012Curr Res ID -1 New Res ID 0 New FPS 30.000000

sadly because 8974 has it limited to 15FPS
so set a prop to tell cameraHAL to set 15FPS universal
12-25 20:40:48.068   406  7811 I mm-camera: sensor_set_resolution:2012Curr Res ID 0 New Res ID 0 New FPS 15.000000

this prevent some apps crash like sometimes in opencamera it request 30FPS but 8974 doesn't support it

Signed-off-by: David Viteri <davidteri91@gmail.com>