### PR TITLE
sony: shinano: Move BT flag

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -21,8 +21,6 @@
 #include <cutils/properties.h>
 #include <string.h>
 
-#define HCILP_INCLUDED FALSE
-
 static inline const char* getBTDefaultName()
 {
     char device[PROPERTY_VALUE_MAX];
@@ -49,6 +47,8 @@ static inline const char* getBTDefaultName()
 
 #define BTM_DEF_LOCAL_NAME getBTDefaultName()
 #endif // OS_GENERIC
+
+#define HCILP_INCLUDED FALSE
 
 /* #define BTA_AV_CO_CP_SCMS_T   TRUE */
 #define SDP_AVRCP_1_5   FALSE


### PR DESCRIPTION
Move HCILP_INCLUDED out of OS_GENERIC #ifdef .

OS_GENERIC flag was used to fix BTDefaultName at Nougat.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I18d9140d85e85c794a3db4f3605fe0950c13cfdf