### PR TITLE
sony: shinano: Increase max number of compression streams

### DIFF
--- a/rootdir/init.shinano.rc
+++ b/rootdir/init.shinano.rc
@@ -17,9 +17,11 @@ import init.common.usb-legacy.rc
 import init.shinano.pwr.rc
 
 on init
-    symlink /dev/block/platform/msm_sdcc.1 /dev/block/bootdevice
+    write /sys/block/zram0/max_comp_streams 4
 
 on fs
+    symlink /dev/block/platform/msm_sdcc.1 /dev/block/bootdevice
+
     mount_all ./fstab.shinano
     swapon_all ./fstab.shinano
     write /sys/kernel/boot_adsp/boot 1


### PR DESCRIPTION
Regardless the value passed to this attribute, ZRAM will always
allocate multiple compression streams - one per online CPUs - thus
allowing several concurrent compression operations. The number of
allocated compression streams goes down when some of the CPUs
become offline. There is no single-compression-stream mode anymore,
unless you are running a UP system or has only 1 CPU online.

Change-Id: I645d22e899735415cc15c821042c4df3b0f169a4
Signed-off-by: Humberto Borba <humberos@gmail.com>